### PR TITLE
✨ feat: add local env management support

### DIFF
--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -1,4 +1,5 @@
 use crate::cli::args::ActivateArgs;
+use crate::store::venv_store::{VenvScope, VenvStore};
 use anyhow::Result;
 
 pub async fn activate(_args: ActivateArgs) -> Result<()> {
@@ -7,4 +8,32 @@ pub async fn activate(_args: ActivateArgs) -> Result<()> {
 
 pub async fn deactivate() -> Result<()> {
     anyhow::bail!("Please run `meowda init <shell_profile>` to set up the activation script.");
+}
+
+pub async fn detect_activate_venv_path(args: ActivateArgs) -> Result<()> {
+    let scope = crate::cli::utils::parse_scope(&args.scope)?;
+    let local_store = VenvStore::create(Some(VenvScope::Local))?;
+    let global_store = VenvStore::create(Some(VenvScope::Global))?;
+    let search_local = scope.is_none() || scope == Some(VenvScope::Local);
+    let search_global = scope.is_none() || scope == Some(VenvScope::Global);
+    let env_name = &args.name;
+
+    if search_local && local_store.is_ready() && local_store.path().join(env_name).exists() {
+        println!("{}", local_store.path().join(env_name).display());
+        return Ok(());
+    }
+    if search_global && global_store.is_ready() && global_store.path().join(env_name).exists() {
+        println!("{}", global_store.path().join(env_name).display());
+        return Ok(());
+    }
+
+    anyhow::bail!(if search_local && search_global {
+        format!("Virtual environment '{env_name}' not found in local or global scope.")
+    } else if search_local {
+        format!("Virtual environment '{env_name}' not found in local scope.")
+    } else if search_global {
+        format!("Virtual environment '{env_name}' not found in global scope.")
+    } else {
+        unreachable!("Unexpected scope combination")
+    })
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -32,6 +32,8 @@ pub enum Commands {
     Uninstall(UninstallArgs),
     #[clap(name = "generate-init-script", hide = true)]
     _GenerateInitScript,
+    #[clap(name = "detect-activate-venv-path", hide = true)]
+    _DetectActivateVenvPath(ActivateArgs),
 }
 
 #[derive(Debug, Parser, PartialEq)]
@@ -52,12 +54,16 @@ pub struct CreateArgs {
         help = "Clear existing virtual environment"
     )]
     pub clear: bool,
+    #[clap(flatten)]
+    pub scope: ScopeArgs,
 }
 
 #[derive(Debug, Parser, PartialEq)]
 pub struct RemoveArgs {
     #[arg(help = "Name of the virtual environment to remove")]
     pub name: String,
+    #[clap(flatten)]
+    pub scope: ScopeArgs,
 }
 
 #[derive(Debug, Parser, PartialEq)]
@@ -73,15 +79,29 @@ pub enum EnvCommandsArgs {
     #[clap(about = "Remove a virtual environment")]
     Remove(RemoveArgs),
     #[clap(about = "List all virtual environments")]
-    List,
+    List(ListArgs),
     #[clap(about = "Show directory of the virtual environment store")]
-    Dir,
+    Dir(DirArgs),
+}
+
+#[derive(Debug, Parser, PartialEq)]
+pub struct ListArgs {
+    #[clap(flatten)]
+    pub scope: ScopeArgs,
+}
+
+#[derive(Debug, Parser, PartialEq)]
+pub struct DirArgs {
+    #[clap(flatten)]
+    pub scope: ScopeArgs,
 }
 
 #[derive(Debug, Parser, PartialEq)]
 pub struct ActivateArgs {
     #[arg(help = "Name of the virtual environment to activate")]
     pub name: String,
+    #[clap(flatten)]
+    pub scope: ScopeArgs,
 }
 
 #[derive(Debug, Parser, PartialEq)]
@@ -102,4 +122,12 @@ pub struct UninstallArgs {
         help = "Uninstall packages from the current virtual environment, the arguments are passed to the `uv pip uninstall` command"
     )]
     pub extra_args: Vec<String>,
+}
+
+#[derive(Debug, Parser, PartialEq)]
+pub struct ScopeArgs {
+    #[arg(long, help = "Select local virtual environment")]
+    pub local: bool,
+    #[arg(long, help = "Select global virtual environment")]
+    pub global: bool,
 }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1,27 +1,35 @@
-use crate::backend::VenvBackend;
-use crate::cli::args::{CreateArgs, RemoveArgs};
+use crate::backend::{EnvInfo, VenvBackend};
+use crate::cli::args::{CreateArgs, DirArgs, ListArgs, RemoveArgs};
+use crate::store::venv_store::VenvScope;
 use anstream::println;
 use anyhow::Result;
 use owo_colors::OwoColorize;
 
 pub async fn create(args: CreateArgs, backend: &VenvBackend) -> Result<()> {
-    backend.create(&args.name, &args.python, args.clear).await?;
+    let scope = crate::cli::utils::parse_scope(&args.scope)?;
+    backend
+        .create(&args.name, &args.python, args.clear, scope)
+        .await?;
     println!("Virtual environment '{}' created successfully.", args.name);
     Ok(())
 }
 
 pub async fn remove(args: RemoveArgs, backend: &VenvBackend) -> Result<()> {
-    backend.remove(&args.name).await?;
+    let scope = crate::cli::utils::parse_scope(&args.scope)?;
+    backend.remove(&args.name, scope).await?;
     println!("Virtual environment '{}' removed successfully.", args.name);
     Ok(())
 }
 
-pub async fn list(backend: &VenvBackend) -> Result<()> {
-    let envs = backend.list().await?;
+fn show_envs(envs: &[EnvInfo], scope: &VenvScope) -> Result<()> {
+    let scope_name = match scope {
+        VenvScope::Local => "local",
+        VenvScope::Global => "global",
+    };
     if envs.is_empty() {
-        println!("No virtual environments found.");
+        println!("No virtual {scope_name} environments found.");
     } else {
-        println!("Available virtual environments:");
+        println!("Available virtual {scope_name} environments:");
         for env in envs {
             let indicator = if env.is_active { "* " } else { "  " };
             let name_display = format!("{}{}", indicator, env.name);
@@ -39,8 +47,21 @@ pub async fn list(backend: &VenvBackend) -> Result<()> {
     Ok(())
 }
 
-pub async fn dir(backend: &VenvBackend) -> Result<()> {
-    let path = backend.dir()?;
+pub async fn list(args: ListArgs, backend: &VenvBackend) -> Result<()> {
+    let (local_envs, global_envs) = backend.list().await?;
+    let scope = crate::cli::utils::parse_scope(&args.scope)?;
+    if scope.is_none() || scope == Some(VenvScope::Local) {
+        show_envs(&local_envs, &VenvScope::Local)?;
+    }
+    if scope.is_none() || scope == Some(VenvScope::Global) {
+        show_envs(&global_envs, &VenvScope::Global)?;
+    }
+    Ok(())
+}
+
+pub async fn dir(args: DirArgs, backend: &VenvBackend) -> Result<()> {
+    let scope = crate::cli::utils::parse_scope(&args.scope)?;
+    let path = backend.dir(scope)?;
     println!("{}", path.display());
     Ok(())
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -28,9 +28,15 @@ function __meowda_hashr() {{
 }}
 
 function __meowda_activate() {{
-    local venv_base=$({exe_path} env dir)
-    local venv_name=$2
-    local venv_path="$venv_base/$venv_name"
+    # Remove the first argument ("meowda activate") from "$@"
+    local activate_args=("${{@:2}}")
+    local venv_path
+    venv_path=$({exe_path} detect-activate-venv-path "${{activate_args[@]}}")
+    local ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "Virtual environment not found or activation failed."
+        return 1
+    fi
     if [ -d "$venv_path" ]; then
         source "$venv_path/bin/activate"
         echo "Activated virtual environment: $venv_path"
@@ -51,7 +57,9 @@ function meowda() {{
         (deactivate) __meowda_deactivate ;;
         (*) __meowda_exe "$@" ;;
     esac
+    local ret=$?
     __meowda_hashr
+    return $ret
 }}
 "#,
     );

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,3 +3,4 @@ pub mod args;
 pub mod env;
 pub mod init;
 pub mod install;
+mod utils;

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,0 +1,18 @@
+use crate::cli;
+use crate::store::venv_store::VenvScope;
+
+pub fn parse_scope(scope_args: &cli::args::ScopeArgs) -> anyhow::Result<Option<VenvScope>> {
+    if scope_args.local && scope_args.global {
+        return Err(anyhow::anyhow!(
+            "Cannot specify both local and global scopes"
+        ));
+    }
+    if !scope_args.local && !scope_args.global {
+        // Unspecified scope
+        return Ok(None);
+    }
+    if scope_args.local {
+        return Ok(Some(VenvScope::Local));
+    }
+    Ok(Some(VenvScope::Global))
+}

--- a/src/envs.rs
+++ b/src/envs.rs
@@ -1,5 +1,6 @@
 pub struct EnvVars;
 
 impl EnvVars {
-    pub const MEOWDA_VENV_DIR: &'static str = "MEOWDA_VENV_DIR";
+    pub const MEOWDA_LOCAL_VENV_DIR: &'static str = "MEOWDA_LOCAL_VENV_DIR";
+    pub const MEOWDA_GLOBAL_VENV_DIR: &'static str = "MEOWDA_GLOBAL_VENV_DIR";
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             cli::args::EnvCommandsArgs::Remove(remove_args) => {
                 cli::env::remove(remove_args, &backend).await
             }
-            cli::args::EnvCommandsArgs::List => cli::env::list(&backend).await,
-            cli::args::EnvCommandsArgs::Dir => cli::env::dir(&backend).await,
+            cli::args::EnvCommandsArgs::List(list_args) => {
+                cli::env::list(list_args, &backend).await
+            }
+            cli::args::EnvCommandsArgs::Dir(dir_args) => cli::env::dir(dir_args, &backend).await,
         },
         cli::args::Commands::Init(init_args) => cli::init::init(init_args).await,
         cli::args::Commands::_GenerateInitScript => cli::init::generate_init_script().await,
@@ -35,6 +37,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             cli::activate::activate(activate_args).await
         }
         cli::args::Commands::Deactivate => cli::activate::deactivate().await,
+        cli::args::Commands::_DetectActivateVenvPath(activate_args) => {
+            cli::activate::detect_activate_venv_path(activate_args).await
+        }
         cli::args::Commands::Install(install_args) => {
             cli::install::install(install_args, &backend).await
         }


### PR DESCRIPTION
支持本地环境管理，为 `create`/`remove`、`activate`、`env list`、`env dir` 等命令添加 `--local` & `--global` 参数

- `--local` 和 `--global` 任何时候不可以一起使用
- `--local` / `--global` 表示强制选择「本地」/「全局」环境
- 在不提供选项时则为默认行为

具体行为在不同命令下有所差异：

- `create`/`remove`/`env dir`，默认选择「全局」环境，可通过 `--local`/`--global` 来强制选择「本地」/「全局」环境
- `activate`，默认优先搜索「本地」环境，后搜索「全局」环境，可通过 `--local`/`--global` 来强制**仅**选择「本地」/「全局」环境
- `env list`，默认同时展示「本地」和「全局」环境，可通过 `--local`/`--global` 来强制**仅**显示「本地」/「全局」环境