### PR TITLE
✨ feat: support link project to venv

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -31,6 +31,10 @@ pub enum Commands {
         about = "Uninstall packages from the current virtual environment (alias for `uv pip uninstall`)"
     )]
     Uninstall(UninstallArgs),
+    #[clap(about = "Link a project to the virtual environment")]
+    Link(LinkArgs),
+    #[clap(about = "Unlink a project from the virtual environment")]
+    Unlink(UnlinkArgs),
     #[clap(name = "generate-init-script", hide = true)]
     _GenerateInitScript,
     #[clap(name = "detect-activate-venv-path", hide = true)]
@@ -123,6 +127,20 @@ pub struct UninstallArgs {
         help = "Uninstall packages from the current virtual environment, the arguments are passed to the `uv pip uninstall` command"
     )]
     pub extra_args: Vec<String>,
+}
+
+#[derive(Debug, Parser, PartialEq)]
+pub struct LinkArgs {
+    #[arg(help = "Name of project to link")]
+    pub name: String,
+    #[arg(help = "Path to the project to link")]
+    pub path: String,
+}
+
+#[derive(Debug, Parser, PartialEq)]
+pub struct UnlinkArgs {
+    #[arg(help = "Name of project to link")]
+    pub name: String,
 }
 
 #[derive(Debug, Parser, PartialEq)]

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -1,0 +1,13 @@
+use crate::backend::VenvBackend;
+use crate::cli::args::{LinkArgs, UnlinkArgs};
+use anyhow::Result;
+
+pub async fn link(args: LinkArgs, backend: &VenvBackend) -> Result<()> {
+    backend.link(&args.name, &args.path).await?;
+    Ok(())
+}
+
+pub async fn unlink(args: UnlinkArgs, backend: &VenvBackend) -> Result<()> {
+    backend.unlink(&args.name).await?;
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,4 +3,5 @@ pub mod args;
 pub mod env;
 pub mod init;
 pub mod install;
+pub mod link;
 mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::args::Commands::Uninstall(uninstall_args) => {
             cli::install::uninstall(uninstall_args, &backend).await
         }
+        cli::args::Commands::Link(link_args) => cli::link::link(link_args, &backend).await,
+        cli::args::Commands::Unlink(unlink_args) => cli::link::unlink(unlink_args, &backend).await,
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
resolves #8

这里使用 editable install 也会使用的 `.pth` 方案，注意 `PYTHONPATH` 和 `.pth` 两者影响效果分别为：

- `PYTHONPATH` 中的（一个或多个）有效路径会被加到 `sys.path` 最前面
- `.pth` 中的（一个或多个）有效路径会被加到 `sys.path` 最后面

作为持久化方案，明显后者是更易于管理的

当然注意，如果支持 editable install 的话建议还是直接 editable install，只有没办法 editable install 的项目才有必要使用 link