### PR TITLE
✨ feat: default create to Python 3.14

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
     name: Ubuntu, ${{ matrix.target }}, Python ${{ matrix.python-version }}
     steps:
@@ -41,7 +41,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         target: [x64, x86]
     name: Windows, ${{ matrix.target }}, Python ${{ matrix.python-version }}
     steps:
@@ -66,7 +66,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         target: [x86_64, aarch64]
     name: macOS, ${{ matrix.target }}, Python ${{ matrix.python-version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Add to your `settings.json`:
 
 **Environment Management**
 
--  `meowda create <name> -p <version>` - Create environment
+-  `meowda create <name> [-p <version>]` - Create environment (defaults to Python 3.14)
 -  `meowda fork <name>` - Fork from the current active environment
 -  `meowda fork <name> --from <env|path>` - Fork from another managed environment or any Python environment path/executable
 -  `meowda activate <name>` - Activate environment

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -57,7 +57,7 @@ pub enum Commands {
 pub struct CreateArgs {
     #[arg(help = "Name of the virtual environment")]
     pub name: String,
-    #[arg(short, long, help = "Python version/path to use (default: 3.13)")]
+    #[arg(short, long, help = "Python version/path to use (default: 3.14)")]
     pub python: Option<String>,
     #[arg(short, long, help = "Clear existing virtual environment")]
     pub clear: bool,

--- a/src/venv/mod.rs
+++ b/src/venv/mod.rs
@@ -183,7 +183,7 @@ impl VenvService {
         create_uv_venv(
             &self.uv_path,
             &venv_path,
-            options.python.unwrap_or("3.13"),
+            options.python.unwrap_or("3.14"),
             true,
             false,
         )?;


### PR DESCRIPTION
## Summary
- change `meowda create` to default to Python 3.14 when `-p/--python` is omitted
- update the CLI help text and README command reference to match the new default
- align the release workflow build matrix with Python 3.14

## Validation
- `cargo run -- create --help`
- `cargo +stable fmt --all`
- `cargo +stable clippy --all-targets --all-features -- -D warnings`
- `cargo +stable test`

<div align="right">
   <sup>This PR is driven by @copilot (gpt-5.4 xhigh)</sup>
</div>